### PR TITLE
Update name of LCG trust anchors

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM gitlab-registry.cern.ch/dmc/gfal2
 
-RUN yum install -y lcg-CA voms-clients voms-config-all gfal2-util fts-client
+RUN yum install -y ca-policy-lcg voms-clients voms-config-all gfal2-util fts-client
 
 # Leave yum cache clean
 RUN yum clean all


### PR DESCRIPTION
Motivation:

Previous RPM package `lcg-CA` is no longer available, resulting in an image without any of the expected trust anchors.

Modification:

Use the `ca-policy-lcg` RPM package instead.

Result:

Image now contains the expected IGTF trust anchors.